### PR TITLE
Play Button, Runtime Render Settings, and Input Event Handling

### DIFF
--- a/Laura/src/Core/Events/IEvent.h
+++ b/Laura/src/Core/Events/IEvent.h
@@ -42,6 +42,7 @@ namespace Laura
 	struct IEvent {
 		virtual ~IEvent() = default;
 		virtual EventType GetType() const = 0;
+		virtual inline bool IsInputEvent() const { return false; }
 
 		inline void Consume() { m_IsConsumed = true; }
 		inline bool IsConsumed() const { return m_IsConsumed; }

--- a/Laura/src/Core/Events/KeyEvents.h
+++ b/Laura/src/Core/Events/KeyEvents.h
@@ -144,6 +144,7 @@ namespace Laura
         	: key(k), keyCtrl(ctrl), keyShift(shift), keyAlt(alt), keySuper(super) {}
 
     	inline EventType GetType() const override { return EventType::KEY_PRESS_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 
 	struct KeyReleaseEvent : public IEvent {
@@ -154,6 +155,7 @@ namespace Laura
         	: key(k), keyCtrl(ctrl), keyShift(shift), keyAlt(alt), keySuper(super) {}
 
     	inline EventType GetType() const override { return EventType::KEY_RELEASE_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 
 	struct KeyRepeatEvent : public IEvent {
@@ -164,5 +166,6 @@ namespace Laura
         	: key(k), keyCtrl(ctrl), keyShift(shift), keyAlt(alt), keySuper(super) {}
 
     	inline EventType GetType() const override { return EventType::KEY_REPEAT_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 }

--- a/Laura/src/Core/Events/MouseEvents.h
+++ b/Laura/src/Core/Events/MouseEvents.h
@@ -32,6 +32,7 @@ namespace Laura
 			: xpos(x), ypos(y) {}
 
 		inline EventType GetType() const override { return EventType::MOUSE_MOVE_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 
 	struct MouseButtonPressEvent : public IEvent {
@@ -41,6 +42,7 @@ namespace Laura
 			: button(btn) {}
 
 		inline EventType GetType() const override { return EventType::MOUSE_BUTTON_PRESS_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 
 	struct MouseButtonReleaseEvent : public IEvent {
@@ -50,6 +52,7 @@ namespace Laura
 			: button(btn) {}
 
 		inline EventType GetType() const override { return EventType::MOUSE_BUTTON_RELEASE_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 
 	struct MouseScrollEvent : public IEvent {
@@ -59,5 +62,6 @@ namespace Laura
 			: xoffset(xoff), yoffset(yoff) {}
 
 		inline EventType GetType() const override { return EventType::MOUSE_SCROLL_EVENT; }
+		inline bool IsInputEvent() const override { return true; }
 	};
 }

--- a/Laura/src/Project/ProjectManager.h
+++ b/Laura/src/Project/ProjectManager.h
@@ -2,6 +2,7 @@
 
 #include "lrpch.h"
 #include <filesystem>
+#include "Renderer/RenderSettings.h"
 #include "Project/Scene/SceneManager.h"
 #include "Project/Assets/AssetManager.h"
 
@@ -17,10 +18,12 @@ namespace Laura
 	#define PROJECT_FILE_EXTENSION ".lrproj"
 
 	struct ProjectFile {
-		ProjectFile(LR_GUID bootSceneGuid = LR_GUID::INVALID) : bootSceneGuid(bootSceneGuid) {}
 		LR_GUID bootSceneGuid = LR_GUID::INVALID;
-	};
+		RenderSettings runtimeRenderSettings{};
 
+		ProjectFile(LR_GUID bootSceneGuid = LR_GUID::INVALID) : bootSceneGuid(bootSceneGuid) {}
+	};
+	
 	/// Serialize the 'projectFile' as-is at the location 'projectFilepath'.
 	/// Returns true on success.
 	bool SaveProjectFile(const std::filesystem::path& projectFilepath, const ProjectFile& projectFile);
@@ -77,6 +80,7 @@ namespace Laura
 		inline LR_GUID GetBootSceneGuid() const { return m_ProjectFile.bootSceneGuid; }
 		inline bool IsBootScene(LR_GUID guid) { return m_ProjectFile.bootSceneGuid == guid; }
 
+		inline RenderSettings& GetMutableRuntimeRenderSettings() { return m_ProjectFile.runtimeRenderSettings; }
 	private:
 		/// Filesystem path to the current project folder (where .lrproj lives).
 		std::filesystem::path m_ProjectPath;

--- a/LauraEditor/src/EditorLayer.cpp
+++ b/LauraEditor/src/EditorLayer.cpp
@@ -17,52 +17,52 @@ namespace Laura
 							 std::shared_ptr<IEventDispatcher> eventDispatcher,
 							 std::shared_ptr<ProjectManager> projectManager,
 							 std::shared_ptr<ImGuiContext> imGuiContext)
-		:	m_EventDispatcher(eventDispatcher),
-			m_ProjectManager(projectManager),
-			m_Profiler(profiler),
-
-			m_EditorState(std::make_shared<EditorState>()),
-			m_ImGuiContext(imGuiContext),
-		
-			m_Launcher(m_EditorState, m_ProjectManager),
-
-			m_MainMenuPanel(std::make_unique<MainMenuPanel>(m_EditorState, m_ProjectManager)),
-			m_SceneHierarchyPanel(std::make_unique<SceneHierarchyPanel>(m_EditorState, m_ProjectManager)),
-			m_InspectorPanel(std::make_unique<InspectorPanel>(m_EditorState, m_ProjectManager)),
-			m_ViewportPanel(std::make_unique<ViewportPanel>(m_EditorState, m_ProjectManager)),
-			m_ThemePanel(std::make_unique<ThemePanel>(m_EditorState)),
-			m_ProfilerPanel(std::make_unique<ProfilerPanel>(m_EditorState, m_Profiler)),
-			m_RenderSettingsPanel(std::make_unique<RenderSettingsPanel>(m_EditorState, m_EventDispatcher)),
-			m_AssetsPanel(std::make_unique<AssetsPanel>(m_EditorState, m_ProjectManager)){
+		: m_Profiler(profiler)
+		, m_EventDispatcher(eventDispatcher)
+		, m_ProjectManager(projectManager)
+		, m_EditorState(std::make_shared<EditorState>())
+		, m_ImGuiContext(imGuiContext)
+		, m_Launcher(m_EditorState, m_ProjectManager)
+		, m_EditorPanels({
+			std::make_unique<MainMenuPanel>(m_EditorState, m_EventDispatcher, m_ProjectManager),
+			std::make_unique<InspectorPanel>(m_EditorState, m_ProjectManager),
+			std::make_unique<SceneHierarchyPanel>(m_EditorState, m_ProjectManager),
+			std::make_unique<ViewportPanel>(m_EditorState, m_ProjectManager),
+			std::make_unique<ThemePanel>(m_EditorState),
+			std::make_unique<ProfilerPanel>(m_EditorState, m_Profiler),
+			std::make_unique<RenderSettingsPanel>(m_EditorState, m_EventDispatcher, m_ProjectManager),
+			std::make_unique<AssetsPanel>(m_EditorState, m_ProjectManager)
+		}){
 	}
 
 	void EditorLayer::onAttach() {
 		deserializeState(m_EditorState);
 
-		m_MainMenuPanel			->init();
-		m_InspectorPanel		->init();
-		m_SceneHierarchyPanel	->init();
-		m_ViewportPanel			->init();
-		m_ThemePanel			->init();
-		m_ProfilerPanel			->init();
-		m_RenderSettingsPanel	->init();
-		m_AssetsPanel			->init();
+		for (auto& panel : m_EditorPanels) {
+			panel->init();
+		}
 	}
 
 	void EditorLayer::onDetach() {
 		serializeState(m_EditorState);
 	}
 
-	void EditorLayer::onEvent(std::shared_ptr<IEvent> event) {
-		// propagate events to individual panels
-		m_MainMenuPanel			->onEvent(event);
-		m_InspectorPanel		->onEvent(event);
-		m_SceneHierarchyPanel	->onEvent(event);
-		m_ViewportPanel			->onEvent(event);
-		m_ThemePanel			->onEvent(event);
-		m_ProfilerPanel			->onEvent(event);
-		m_RenderSettingsPanel	->onEvent(event);
-		m_AssetsPanel			->onEvent(event);
+	void EditorLayer::onEvent(std::shared_ptr<IEvent> event) { 
+		// while in editor mode - consume input events
+		if (!m_EditorState->temp.isInRuntimeMode && event->IsInputEvent()) {
+			event->Consume();
+			return; // don't propagate further
+		}
+
+		for (auto& panel : m_EditorPanels) {
+			panel->onEvent(event);
+			if (event->IsConsumed()) {
+				break;
+			}
+		}
+
+		if (event->GetType() != EventType::NEW_FRAME_RENDERED_EVENT)
+			std::cout << event->GetType() << std::endl;
 	}
 
 	void EditorLayer::onUpdate() {
@@ -76,14 +76,9 @@ namespace Laura
 		}
 
 		ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
-		m_MainMenuPanel			->OnImGuiRender();
-		m_SceneHierarchyPanel	->OnImGuiRender();
-		m_InspectorPanel		->OnImGuiRender();
-		m_ThemePanel			->OnImGuiRender();
-		m_AssetsPanel			->OnImGuiRender();
-		m_RenderSettingsPanel	->OnImGuiRender();
-		m_ViewportPanel			->OnImGuiRender();
-		m_ProfilerPanel			->OnImGuiRender();
+		for (auto& panel : m_EditorPanels) {
+			panel->OnImGuiRender();
+		}
 
 		bool showDemo = true;
 		ImGui::ShowDemoWindow(&showDemo);

--- a/LauraEditor/src/EditorLayer.h
+++ b/LauraEditor/src/EditorLayer.h
@@ -35,13 +35,6 @@ namespace Laura
 		Launcher m_Launcher;
 
 		// Editor Panels
-		std::unique_ptr<IEditorPanel> m_MainMenuPanel;
-		std::unique_ptr<IEditorPanel> m_SceneHierarchyPanel;
-		std::unique_ptr<IEditorPanel> m_InspectorPanel;
-		std::unique_ptr<IEditorPanel> m_ViewportPanel;
-		std::unique_ptr<IEditorPanel> m_ThemePanel;
-		std::unique_ptr<IEditorPanel> m_ProfilerPanel;
-		std::unique_ptr<IEditorPanel> m_RenderSettingsPanel;
-		std::unique_ptr<IEditorPanel> m_AssetsPanel;
+		std::array<std::unique_ptr<IEditorPanel>, 8> m_EditorPanels;
 	};
 }

--- a/LauraEditor/src/EditorState.h
+++ b/LauraEditor/src/EditorState.h
@@ -32,6 +32,7 @@ namespace Laura
 			bool isThemePanelOpen = false;
 			bool isProfilerPanelOpen = true;
 			EditorTheme editorTheme;
+			bool isInRuntimeMode = false;
 		} temp;
 
 		// TO ADD new persistent entries, add them here and update the SERIALIZE and DESERIALIZE functions 

--- a/LauraEditor/src/EditorUI/AssetsPanel/AssetsPanel.cpp
+++ b/LauraEditor/src/EditorUI/AssetsPanel/AssetsPanel.cpp
@@ -8,10 +8,18 @@ namespace Laura
 
 	void AssetsPanel::OnImGuiRender() {
         EditorTheme& theme = m_EditorState->temp.editorTheme;
+        
+        
         theme.PushColor(ImGuiCol_WindowBg, EditorCol_Background1);
         ImGui::Begin(ICON_FA_CUBE " ASSETS");
+        if (m_EditorState->temp.isInRuntimeMode) {
+            ImGui::BeginDisabled();
+        }
 
         if (!m_ProjectManager->ProjectIsOpen()) {
+            if (m_EditorState->temp.isInRuntimeMode) {
+                ImGui::EndDisabled();
+            }
             ImGui::End();
             theme.PopColor();
             return;
@@ -107,6 +115,10 @@ namespace Laura
             DrawTileInfo();
             ImGui::EndTable();
         }
+        if (m_EditorState->temp.isInRuntimeMode) {
+            ImGui::EndDisabled();
+        }
+        
         ImGui::End();
         theme.PopColor(); // WindowBg, Background3
     }

--- a/LauraEditor/src/EditorUI/InspectorPanel/InspectorPanel.cpp
+++ b/LauraEditor/src/EditorUI/InspectorPanel/InspectorPanel.cpp
@@ -1,5 +1,6 @@
 #include "EditorUI/InspectorPanel/InspectorPanel.h"
 #include "EditorUI/InspectorPanel/TransformUI.h"
+#include "EditorUI/UtilityUI.h"
 
 namespace Laura
 {
@@ -12,11 +13,17 @@ namespace Laura
     void InspectorPanel::OnImGuiRender() {
 		EditorTheme& theme = m_EditorState->temp.editorTheme;
 		
+		
 		ImGui::SetNextWindowSizeConstraints({ 350, 50 }, {FLT_MAX, FLT_MAX});
 		ImGui::Begin(ICON_FA_CIRCLE_INFO " INSPECTOR");
-		
+		if (m_EditorState->temp.isInRuntimeMode) {
+			ImGui::BeginDisabled();
+		}
 
         if (!m_ProjectManager->ProjectIsOpen()) {
+			if (m_EditorState->temp.isInRuntimeMode) {
+				ImGui::EndDisabled();
+			}
             ImGui::End();
             return;
         }
@@ -24,6 +31,9 @@ namespace Laura
         std::shared_ptr<Scene> scene = m_ProjectManager->GetSceneManager()->GetOpenScene();
 
         if (scene == nullptr || m_EditorState->temp.selectedEntity == entt::null) {
+			if (m_EditorState->temp.isInRuntimeMode) {
+				ImGui::EndDisabled();
+			}
 			ImGui::End();
 			return;
 		}
@@ -174,6 +184,11 @@ namespace Laura
 		// ensure that there is always some space under the Add Component button when scrolling to display the popup
 		ImGui::Dummy(ImVec2(0.0f, 100.0f)); 
 		theme.PopColor();
+		
+		if (m_EditorState->temp.isInRuntimeMode) {
+			ImGui::EndDisabled();
+		}
+		
         ImGui::End();
     }
 }

--- a/LauraEditor/src/EditorUI/MainMenuPanel/MainMenuPanel.cpp
+++ b/LauraEditor/src/EditorUI/MainMenuPanel/MainMenuPanel.cpp
@@ -8,8 +8,13 @@ namespace Laura
 {
 
 	void Laura::MainMenuPanel::OnImGuiRender() {
+		auto& theme = m_EditorState->temp.editorTheme;
 		static bool shouldCloseProject = false;
 		if (ImGui::BeginMainMenuBar()) {
+			if (m_EditorState->temp.isInRuntimeMode) {
+				ImGui::BeginDisabled();
+			}
+			float playBtnPos = (ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(ICON_FA_PLAY).x) / 2.0f;
 			if (ImGui::BeginMenu("File")) {
 				if (ImGui::MenuItem("Save")) { m_ProjectManager->SaveProject(); }
 				if (ImGui::MenuItem("Close")) { shouldCloseProject = true; }
@@ -26,6 +31,27 @@ namespace Laura
 				if (profilerPanelDisabled) { ImGui::EndDisabled(); }
 				ImGui::EndMenu();
 			}
+			if (m_EditorState->temp.isInRuntimeMode) {
+				ImGui::EndDisabled();
+			}
+
+			ImGui::SetCursorPosX(playBtnPos);
+			EditorCol_ btnIconCol = (m_EditorState->temp.isInRuntimeMode) ? EditorCol_Warning : EditorCol_Text1;
+			std::string btnIcon = (m_EditorState->temp.isInRuntimeMode) ? ICON_FA_SQUARE : ICON_FA_PLAY;
+			theme.PushColor(ImGuiCol_Button, EditorCol_Transparent);
+			theme.PushColor(ImGuiCol_Text, btnIconCol);
+			if (ImGui::Button(btnIcon.c_str())) {
+				m_EditorState->temp.isInRuntimeMode = !m_EditorState->temp.isInRuntimeMode;
+
+				if (m_EditorState->temp.isInRuntimeMode) { // set runtime settings
+					m_EventDispatcher->dispatchEvent(std::make_shared<UpdateRenderSettingsEvent>(m_ProjectManager->GetMutableRuntimeRenderSettings()));
+				}
+				else { // set editor settings
+					m_EventDispatcher->dispatchEvent(std::make_shared<UpdateRenderSettingsEvent>(m_EditorState->persistent.editorRenderSettings));
+				}
+			}
+			theme.PopColor(2);
+
 			ImGui::EndMainMenuBar();
 		}
 

--- a/LauraEditor/src/EditorUI/MainMenuPanel/MainMenuPanel.h
+++ b/LauraEditor/src/EditorUI/MainMenuPanel/MainMenuPanel.h
@@ -9,8 +9,14 @@ namespace Laura
 
 	class MainMenuPanel : public IEditorPanel {
 	public:
-		MainMenuPanel(std::shared_ptr<EditorState> editorState, std::shared_ptr<ProjectManager> projectManager)
-			: m_EditorState(editorState), m_ProjectManager(projectManager) {}
+		MainMenuPanel(std::shared_ptr<EditorState> editorState, 
+					  std::shared_ptr<IEventDispatcher> eventDispatcher, 
+			          std::shared_ptr<ProjectManager> projectManager)
+			: m_EditorState(editorState)
+			, m_EventDispatcher(eventDispatcher)
+			, m_ProjectManager(projectManager) 
+		{}
+
 		~MainMenuPanel() = default;
 
 		virtual inline void init() override {}
@@ -19,6 +25,7 @@ namespace Laura
 
 	private:
 		std::shared_ptr<EditorState> m_EditorState;
+		std::shared_ptr<IEventDispatcher> m_EventDispatcher;
 		std::shared_ptr<ProjectManager> m_ProjectManager;
 	};
 }

--- a/LauraEditor/src/EditorUI/ProfilerPanel/ProfilerPanel.cpp
+++ b/LauraEditor/src/EditorUI/ProfilerPanel/ProfilerPanel.cpp
@@ -1,6 +1,7 @@
 #include <IconsFontAwesome6.h>
 #include <implot.h>
 #include "ProfilerPanel.h"
+#include "EditorUI/UtilityUI.h"
 
 namespace Laura 
 {
@@ -12,8 +13,12 @@ namespace Laura
             return;
         }
 
+
         if (!m_Profiler->globalTimerSet) {
             LOG_ENGINE_WARN("Unable to render Profiler Panel - No Global Timer Set");
+            if (m_EditorState->temp.isInRuntimeMode) {
+                ImGui::EndDisabled();
+            }
             return;
         }
 
@@ -22,6 +27,9 @@ namespace Laura
         ImPlot::PushColormap(ImPlotColormap_Deep);
         theme.PushColor(ImGuiCol_WindowBg, EditorCol_Background3);
         ImGui::Begin(ICON_FA_STOPWATCH " PROFILER", &m_EditorState->temp.isProfilerPanelOpen);
+        if (m_EditorState->temp.isInRuntimeMode) {
+            ImGui::BeginDisabled();
+        }
 
         const char* playLabel = (m_Profiler->isPaused) ? ICON_FA_PLAY : ICON_FA_PAUSE;
         theme.PushColor(ImGuiCol_Button, EditorCol_Transparent);
@@ -99,6 +107,11 @@ namespace Laura
             ImPlot::EndSubplots();
         }
         theme.PopColor(); // frameBg
+        
+        if (m_EditorState->temp.isInRuntimeMode) {
+            ImGui::EndDisabled();
+        }
+        
         ImGui::End();
         ImPlot::PopColormap();
         theme.PopColor(); // windowBg

--- a/LauraEditor/src/EditorUI/RenderSettingsPanel/RenderSettingsPanel.h
+++ b/LauraEditor/src/EditorUI/RenderSettingsPanel/RenderSettingsPanel.h
@@ -10,8 +10,8 @@ namespace Laura
 
 	class RenderSettingsPanel : public IEditorPanel {
 	public:
-		RenderSettingsPanel(std::shared_ptr<EditorState> editorState, std::shared_ptr<IEventDispatcher> eventDispatcher)
-			: m_EditorState(editorState), m_EventDispatcher(eventDispatcher) {
+		RenderSettingsPanel(std::shared_ptr<EditorState> editorState, std::shared_ptr<IEventDispatcher> eventDispatcher, std::shared_ptr<ProjectManager> projectManager)
+			: m_EditorState(editorState), m_EventDispatcher(eventDispatcher), m_ProjectManager(projectManager) {
         }
 
 		~RenderSettingsPanel() = default;
@@ -55,5 +55,6 @@ namespace Laura
 
 		std::shared_ptr<EditorState> m_EditorState;
         std::shared_ptr<IEventDispatcher> m_EventDispatcher;
+        std::shared_ptr<ProjectManager> m_ProjectManager;
 	};
 }

--- a/LauraEditor/src/EditorUI/SceneHierarchyPanel/SceneHierarchyPanel.cpp
+++ b/LauraEditor/src/EditorUI/SceneHierarchyPanel/SceneHierarchyPanel.cpp
@@ -11,9 +11,17 @@ namespace Laura
 
     void SceneHierarchyPanel::OnImGuiRender() {
         EditorTheme& theme = m_EditorState->temp.editorTheme;
+        
+        
         ImGui::Begin(ICON_FA_FOLDER_TREE " SCENE HIERARCHY");
+        if (m_EditorState->temp.isInRuntimeMode) {
+            ImGui::BeginDisabled();
+        }
 
         if (!m_ProjectManager->ProjectIsOpen()) {
+            if (m_EditorState->temp.isInRuntimeMode) {
+                ImGui::EndDisabled();
+            }
             ImGui::End();
             return;
         }
@@ -94,6 +102,11 @@ namespace Laura
 		}
 
         ImGui::PopStyleVar();
+        
+        if (m_EditorState->temp.isInRuntimeMode) {
+            ImGui::EndDisabled();
+        }
+        
         ImGui::End();
     }
 }

--- a/LauraEditor/src/EditorUI/ThemePanel/ThemePanel.cpp
+++ b/LauraEditor/src/EditorUI/ThemePanel/ThemePanel.cpp
@@ -12,6 +12,7 @@ namespace Laura
 			return;
 		}
 
+
 		static std::string errorMessage = "";
 		auto& theme = m_EditorState->temp.editorTheme;
 		ImGuiWindowFlags ThemePanelFlags = ImGuiWindowFlags_NoDocking;
@@ -20,6 +21,9 @@ namespace Laura
 		ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(3, 3));
 		theme.PushColor(ImGuiCol_WindowBg, EditorCol_Background3);
 		ImGui::Begin(ICON_FA_BRUSH " THEMES", &m_EditorState->temp.isThemePanelOpen, ThemePanelFlags);
+		if (m_EditorState->temp.isInRuntimeMode) {
+			ImGui::BeginDisabled();
+		}
 
 		if (ImGui::BeginTabBar("##tabs", ImGuiTabBarFlags_None)) {
 			float lineHeight = GImGui->Font->FontSize + GImGui->Style.FramePadding.y * 2.0f;
@@ -160,6 +164,10 @@ namespace Laura
 			ImGui::EndTabBar();
 		}
 
+		if (m_EditorState->temp.isInRuntimeMode) {
+			ImGui::EndDisabled();
+		}
+		
 		ImGui::End();
 		theme.PopColor();
 		ImGui::PopStyleVar();

--- a/LauraEditor/src/EditorUI/UtilityUI.h
+++ b/LauraEditor/src/EditorUI/UtilityUI.h
@@ -118,5 +118,4 @@ namespace Laura
 		theme.PopColor();
 		ImGui::PopStyleVar();
 	}
-
 }

--- a/LauraEditor/src/EditorUI/ViewportPanel/ViewportPanel.cpp
+++ b/LauraEditor/src/EditorUI/ViewportPanel/ViewportPanel.cpp
@@ -2,6 +2,7 @@
 #include <IconsFontAwesome6.h>
 #include <imgui_internal.h>
 #include "EditorUI/DNDPayloads.h"
+#include "EditorUI/UtilityUI.h"
 
 namespace Laura
 {
@@ -30,12 +31,17 @@ namespace Laura
 		static ImGuiWindowFlags ViewportFlags = ImGuiWindowFlags_NoCollapse;
 		auto theme = m_EditorState->temp.editorTheme;
 
+
 		ImGuiStyle& style = ImGui::GetStyle();
 		ImVec4 originalWindowBG = style.Colors[ImGuiCol_WindowBg];
 		theme.PushColor(ImGuiCol_WindowBg, EditorCol_Background2);
 		
 		ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2{ 0, 0 }); // remove the border padding
 		ImGui::Begin(ICON_FA_EYE " VIEWPORT", nullptr, ViewportFlags);
+		if (m_EditorState->temp.isInRuntimeMode) {
+			ImGui::BeginDisabled();
+		}
+
 		ImGui::BeginChild("DropArea");
 	
 		ImGuiWindow* window = ImGui::GetCurrentWindow();
@@ -49,6 +55,11 @@ namespace Laura
 			ImGui::EndChild();
 			ImGui::PopStyleVar();
 			DrawDropTargetForScene();
+			
+			if (m_EditorState->temp.isInRuntimeMode) {
+				ImGui::EndDisabled();
+			}
+			
 			ImGui::End();
 			theme.PopColor();
 			return;
@@ -122,6 +133,10 @@ namespace Laura
 		ImGui::EndChild();
 		ImGui::PopStyleVar();
 		DrawDropTargetForScene();
+
+		if (m_EditorState->temp.isInRuntimeMode) {
+			ImGui::EndDisabled();
+		}
 
 		ImGui::End();
 		theme.PopColor();


### PR DESCRIPTION
## Summary of Changes
- **Play Button** – Added a play button to the main menu to toggle between edit and runtime modes.  
- **Runtime Render Settings** – Added dedicated runtime render settings with serialization/deserialization in the project file.  
- **Input Event Consumption** – Updated `EditorLayer` to consume input events while in runtime mode, preventing propagation to editor UI.  
- **Panel Refactor** – All panels now inherit from a common `IEditorPanel` interface. The editor stores them in a single array and iterates over them for lifecycle calls such as `Init()` `OnImGuiRender()` & `OnEvent()`.
