### PR TITLE
Add Linux build support (GCC) and preserve HWND handling in dialogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.26)
 
-# Platform check - only allow Windows for now
-if(NOT WIN32)
-    message(WARNING "Laura engine currently only supports Windows platform")
-endif()
-
 # if BUILD_INSTALL = ON -> LauraEngine target defines #define BUILD_INSTALL
 # and propagates the macro to Runtime & Editor
 option(BUILD_INSTALL "Use installed paths instead of source-tree paths" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.26)
 
 # Platform check - only allow Windows for now
 if(NOT WIN32)
-    message(FATAL_ERROR "Laura engine currently only supports Windows platform")
+    message(WARNING "Laura engine currently only supports Windows platform")
 endif()
 
 # if BUILD_INSTALL = ON -> LauraEngine target defines #define BUILD_INSTALL

--- a/Laura/CMakeLists.txt
+++ b/Laura/CMakeLists.txt
@@ -34,6 +34,11 @@ target_precompile_headers(LauraEngine PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/l
 target_link_libraries(LauraEngine PUBLIC glm spdlog::spdlog entt yaml-cpp) 
 target_link_libraries(LauraEngine PUBLIC assimp glfw libglew_static stb_image stb_truetype) 
 
+# Suppress array-bounds warning only for assimp
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(assimp PRIVATE -Wno-array-bounds)
+endif()
+
 
 # DEFINES 
 target_compile_definitions(LauraEngine PUBLIC

--- a/Laura/src/Core/Events/KeyEvents.h
+++ b/Laura/src/Core/Events/KeyEvents.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Core\Events\IEvent.h"
+#include "Core/Events/IEvent.h"
 
 namespace Laura 
 {

--- a/Laura/src/Core/IWindow.cpp
+++ b/Laura/src/Core/IWindow.cpp
@@ -1,5 +1,5 @@
-#include "core/IWindow.h"
-#include "platform/windows/GLFWWindow.h"
+#include "Core/IWindow.h"
+#include "Platform/Windows/GLFWWindow.h"
 
 namespace Laura
 {

--- a/Laura/src/Core/Log.cpp
+++ b/Laura/src/Core/Log.cpp
@@ -1,4 +1,4 @@
-#include "core/Log.h"
+#include "Core/Log.h"
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace Laura 

--- a/Laura/src/Export/ProjectExporter.cpp
+++ b/Laura/src/Export/ProjectExporter.cpp
@@ -123,11 +123,19 @@ namespace Laura
             }
             copyInto(exportProjectFolderPath, runtimePath);
 
-            // Rename the runtime .exe file
-            std::filesystem::rename(
+			
+			// Rename the runtime executable file
+			#if defined(_WIN32)
+			std::filesystem::rename(
 				exportProjectFolderPath / "LauraRuntime.exe", // hardcoded string (not ideal)
 				exportProjectFolderPath / (projectName + ".exe")
 			);
+			#else
+			std::filesystem::rename(
+				exportProjectFolderPath / "LauraRuntime",
+				exportProjectFolderPath / projectName
+			);
+			#endif
 
 			#ifdef BUILD_INSTALL
 			// Copy engine resources into export folder.

--- a/Laura/src/Platform/OpenGL/OpenGLComputeShader.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLComputeShader.cpp
@@ -1,6 +1,6 @@
 #include <GL/glew.h>
-#include "platform/OpenGL/OpenGLComputeShader.h"
-#include "platform/OpenGL/OpenGLdebugFuncs.h"
+#include "Platform/OpenGL/OpenGLComputeShader.h"
+#include "Platform/OpenGL/OpenGLdebugFuncs.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLComputeShader.h
+++ b/Laura/src/Platform/OpenGL/OpenGLComputeShader.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "lrpch.h"
-#include "renderer/IComputeShader.h"
+#include "Renderer/IComputeShader.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLContext.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLContext.cpp
@@ -1,7 +1,7 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
-#include "platform/OpenGL/OpenGLContext.h"
-#include "core/Log.h"
+#include "Platform/OpenGL/OpenGLContext.h"
+#include "Core/Log.h"
 
 namespace Laura 
 { 

--- a/Laura/src/Platform/OpenGL/OpenGLContext.h
+++ b/Laura/src/Platform/OpenGL/OpenGLContext.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "renderer/IRenderingContext.h"
-#include "core/IWindow.h"
+#include "Renderer/IRenderingContext.h"
+#include "Core/IWindow.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLImage2D.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLImage2D.cpp
@@ -1,5 +1,5 @@
-#include "platform/OpenGL/OpenGLImage2D.h"
-#include "platform/OpenGL/OpenGLdebugFuncs.h"
+#include "Platform/OpenGL/OpenGLImage2D.h"
+#include "Platform/OpenGL/OpenGLdebugFuncs.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLImage2D.h
+++ b/Laura/src/Platform/OpenGL/OpenGLImage2D.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "lrpch.h"
-#include <gl/glew.h>
-#include "renderer/IImage2D.h"
+#include <GL/glew.h>
+#include "Renderer/IImage2D.h"
 #include "glm/glm.hpp"
 
 namespace Laura 

--- a/Laura/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -1,6 +1,6 @@
-#include "platform/OpenGL/OpenGLRendererAPI.h"
+#include "Platform/OpenGL/OpenGLRendererAPI.h"
 #include <GL/glew.h>
-#include "renderer/IComputeShader.h"
+#include "Renderer/IComputeShader.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLRendererAPI.h
+++ b/Laura/src/Platform/OpenGL/OpenGLRendererAPI.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "lrpch.h"
-#include "renderer/IRendererAPI.h"
+#include "Renderer/IRendererAPI.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLShaderStorageBuffer.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLShaderStorageBuffer.cpp
@@ -1,6 +1,6 @@
 #include "OpenGLShaderStorageBuffer.h"
 #include <GL/glew.h>
-#include "platform/OpenGL/OpenGLdebugFuncs.h"
+#include "Platform/OpenGL/OpenGLdebugFuncs.h"
 
 namespace Laura
 {

--- a/Laura/src/Platform/OpenGL/OpenGLShaderStorageBuffer.h
+++ b/Laura/src/Platform/OpenGL/OpenGLShaderStorageBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "lrpch.h"
-#include "renderer/IShaderStorageBuffer.h"
+#include "Renderer/IShaderStorageBuffer.h"
 
 namespace Laura
 {

--- a/Laura/src/Platform/OpenGL/OpenGLTexture2D.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLTexture2D.cpp
@@ -1,6 +1,6 @@
-#include "platform/OpenGL/OpenGLTexture2D.h"
-#include <gl/glew.h>
-#include "platform/OpenGL/OpenGLdebugFuncs.h"
+#include "Platform/OpenGL/OpenGLTexture2D.h"
+#include <GL/glew.h>
+#include "Platform/OpenGL/OpenGLdebugFuncs.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLUniformBuffer.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLUniformBuffer.cpp
@@ -1,6 +1,6 @@
 #include "OpenGLUniformBuffer.h"
 #include <GL/glew.h>
-#include "platform/OpenGL/OpenGLdebugFuncs.h"
+#include "Platform/OpenGL/OpenGLdebugFuncs.h"
 
 namespace Laura {
 

--- a/Laura/src/Platform/OpenGL/OpenGLUniformBuffer.h
+++ b/Laura/src/Platform/OpenGL/OpenGLUniformBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "lrpch.h"
-#include "renderer/IUniformBuffer.h"
+#include "Renderer/IUniformBuffer.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/OpenGL/OpenGLdebugFuncs.cpp
+++ b/Laura/src/Platform/OpenGL/OpenGLdebugFuncs.cpp
@@ -1,4 +1,4 @@
-#include "platform/OpenGL/OpenGLdebugFuncs.h"
+#include "Platform/OpenGL/OpenGLdebugFuncs.h"
 #include <iostream>
 
 namespace Laura 

--- a/Laura/src/Platform/OpenGL/OpenGLdebugFuncs.h
+++ b/Laura/src/Platform/OpenGL/OpenGLdebugFuncs.h
@@ -2,10 +2,19 @@
 
 #include <GL/glew.h>
 
+#if defined(_MSC_VER)
+    #define DEBUG_BREAK() __debugbreak()
+#elif defined(__GNUC__) || defined(__clang__)
+    #include <signal.h>
+    #define DEBUG_BREAK() raise(SIGTRAP)
+#else
+    #define DEBUG_BREAK() ((void)0)
+#endif
+
 namespace Laura 
 {
 
-	#define ASSERT(x) if (!(x)) __debugbreak();
+	#define ASSERT(x) if (!(x)) DEBUG_BREAK()
 
 	#define GLCall(x) GLClearError();\
 	x;\

--- a/Laura/src/Platform/Windows/GLFWWindow.cpp
+++ b/Laura/src/Platform/Windows/GLFWWindow.cpp
@@ -4,7 +4,7 @@
 #include "Core/Events/KeyEvents.h"
 #include "Core/Events/MouseEvents.h"
 #include "Core/Events/WindowEvents.h"
-#include "core/Log.h"
+#include "Core/Log.h"
 
 namespace Laura 
 {

--- a/Laura/src/Platform/Windows/GLFWWindow.h
+++ b/Laura/src/Platform/Windows/GLFWWindow.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <GLFW/glfw3.h>
-#include "core/IWindow.h"
-#include "platform/OpenGL/OpenGLContext.h"
+#include "Core/IWindow.h"
+#include "Platform/OpenGL/OpenGLContext.h"
 #include "Core/Events/KeyEvents.h"
 #include "Core/Events/MouseEvents.h"
 

--- a/Laura/src/Renderer/IComputeShader.cpp
+++ b/Laura/src/Renderer/IComputeShader.cpp
@@ -1,6 +1,6 @@
 #include "Renderer/IComputeShader.h"
 #include "Renderer/IRendererAPI.h"
-#include "platform/OpenGL/OpenGLComputeShader.h"
+#include "Platform/OpenGL/OpenGLComputeShader.h"
 
 namespace Laura 
 {

--- a/Laura/src/Renderer/IRendererAPI.cpp
+++ b/Laura/src/Renderer/IRendererAPI.cpp
@@ -1,5 +1,5 @@
 #include "Renderer/IRendererAPI.h"
-#include "platform/opengl/OpenGLRendererAPI.h"
+#include "Platform/OpenGL/OpenGLRendererAPI.h"
 
 namespace Laura 
 {

--- a/Laura/src/Renderer/IRendererAPI.h
+++ b/Laura/src/Renderer/IRendererAPI.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "lrpch.h"
-#include "renderer/IComputeShader.h"
+#include "Renderer/IComputeShader.h"
 
 namespace Laura 
 {

--- a/Laura/src/Renderer/Renderer.cpp
+++ b/Laura/src/Renderer/Renderer.cpp
@@ -1,4 +1,4 @@
-#include "renderer/Renderer.h"
+#include "Renderer/Renderer.h"
 #include <glm/gtc/matrix_access.hpp>
 #include "Project/Scene/Scene.h"
 #include "Project/Assets/AssetManager.h"

--- a/LauraEditor/src/Dialogs/FilePickerDialog.h
+++ b/LauraEditor/src/Dialogs/FilePickerDialog.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(_WIN32)
+    #include "Platform/Windows/Dialogs/FilePickerDialog.h"
+#elif defined(__linux__)
+    #include "Platform/Linux/Dialogs/FilePickerDialog.h"
+#else
+    #error "Unsupported platform for FilePickerDialog"
+#endif

--- a/LauraEditor/src/Dialogs/FolderPickerDialog.h
+++ b/LauraEditor/src/Dialogs/FolderPickerDialog.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(_WIN32)
+    #include "Platform/Windows/Dialogs/FolderPickerDialog.h"
+#elif defined(__linux__)
+    #include "Platform/Linux/Dialogs/FolderPickerDialog.h"
+#else
+    #error "Unsupported platform for FolderPickerDialog"
+#endif

--- a/LauraEditor/src/Dialogs/ProjectDialogs/ProjectDialogs.h
+++ b/LauraEditor/src/Dialogs/ProjectDialogs/ProjectDialogs.h
@@ -3,8 +3,8 @@
 #include <filesystem>
 #include "Laura.h"
 #include "EditorState.h"
-#include "Platform/Windows/Dialogs/FolderPickerDialog.h"
-#include "Platform/Windows/Dialogs/FilePickerDialog.h"
+#include "Dialogs/FolderPickerDialog.h"
+#include "Dialogs/FilePickerDialog.h"
 
 namespace Laura
 {

--- a/LauraEditor/src/ImGuiContext.cpp
+++ b/LauraEditor/src/ImGuiContext.cpp
@@ -3,8 +3,8 @@
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 #include <IconsFontAwesome6.h>
-#include <iconsFontAwesome6Brands.h>
-#include <GLFW\glfw3.h>
+#include <IconsFontAwesome6Brands.h>
+#include <GLFW/glfw3.h>
 #include <implot.h>
 #include "ImGuiContext.h"
 #include "EditorCfg.h"

--- a/LauraEditor/src/Panels/AssetsPanel/AssetsPanel.cpp
+++ b/LauraEditor/src/Panels/AssetsPanel/AssetsPanel.cpp
@@ -2,7 +2,7 @@
 #include "Dialogs/ConfirmationDialog.h"
 #include "Project/Scene/SceneManager.h"
 #include "Project/Assets/AssetManager.h"
-#include "Platform/Windows/Dialogs/FilePickerDialog.h"
+#include "Dialogs/FilePickerDialog.h"
 #include "Panels/DNDPayloads.h"
 #include "ImGuiContextFontRegistry.h"
 #include <format>

--- a/LauraEditor/src/Panels/AssetsPanel/AssetsPanel.h
+++ b/LauraEditor/src/Panels/AssetsPanel/AssetsPanel.h
@@ -4,7 +4,7 @@
 #include "Panels/IEditorPanel.h"
 #include "EditorState.h"
 #include "IconsFontAwesome6.h"
-#include "Panels\DNDPayloads.h"
+#include "Panels/DNDPayloads.h"
 
 namespace Laura 
 {

--- a/LauraEditor/src/Panels/ExportPanel/ExportPanel.cpp
+++ b/LauraEditor/src/Panels/ExportPanel/ExportPanel.cpp
@@ -1,6 +1,6 @@
 #include "ExportPanel.h"
 #include <IconsFontAwesome6.h>
-#include "Platform/Windows/Dialogs/FolderPickerDialog.h"
+#include "Dialogs/FolderPickerDialog.h"
 #include "Export/ExportSettings.h"
 #include "Export/ProjectExporter.h"
 #include "Panels/DNDPayloads.h"

--- a/LauraEditor/src/Panels/Launcher/Launcher.cpp
+++ b/LauraEditor/src/Panels/Launcher/Launcher.cpp
@@ -1,7 +1,7 @@
 #include <IconsFontAwesome6.h>
 #include "Launcher.h"
-#include "Platform/Windows/Dialogs/FolderPickerDialog.h"
-#include "Platform/Windows/Dialogs/FilePickerDialog.h"
+#include "Dialogs/FolderPickerDialog.h"
+#include "Dialogs/FilePickerDialog.h"
 #include "Project/ProjectManager.h"  // For PROJECT_FILE_EXTENSION
 #include "ImGuiContextFontRegistry.h"
 

--- a/LauraEditor/src/Panels/ThemePanel/ThemePanel.cpp
+++ b/LauraEditor/src/Panels/ThemePanel/ThemePanel.cpp
@@ -3,7 +3,7 @@
 #include <filesystem>
 #include "ThemePanel.h"
 #include "Dialogs/ConfirmationDialog.h"
-#include "Platform/Windows/Dialogs/FilePickerDialog.h"
+#include "Dialogs/FilePickerDialog.h"
 
 namespace Laura
 {

--- a/LauraEditor/src/Platform/Linux/Dialogs/FilePickerDialog.h
+++ b/LauraEditor/src/Platform/Linux/Dialogs/FilePickerDialog.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <cstdlib>
+#include <cstdio>
+
+namespace Laura
+{
+
+    using NativeWindowHandle = void*; // Ignored on Linux
+
+    inline std::filesystem::path FilePickerDialog(
+        const char* ext,
+        const char* title,
+        NativeWindowHandle owner = nullptr
+    ) {
+        // Build Zenity command
+        std::string cmd = "zenity --file-selection --title=\"";
+        cmd += title ? title : "Select File";
+        cmd += "\"";
+
+        if (ext && *ext) {
+            std::string pattern = ext;
+            if (pattern.rfind("*.") != 0) {
+                if (pattern[0] == '.') {
+                    pattern = "*" + pattern;
+                } else {
+                    pattern = "*." + pattern;
+                }
+            }
+            cmd += " --file-filter=\"*";
+            cmd += pattern.substr(1);
+            cmd += "\"";
+        }
+
+        cmd += " 2>/dev/null"; // suppress warnings
+
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) {
+            return {};
+        }
+
+        char buffer[4096];
+        std::string result;
+        while (fgets(buffer, sizeof(buffer), pipe)) {
+            result += buffer;
+        }
+        pclose(pipe);
+
+        if (!result.empty() && result.back() == '\n') {
+            result.pop_back();
+        }
+
+        return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
+    }
+
+    inline std::filesystem::path SaveFileDialog(
+        const char* ext,
+        const char* title,
+        const char* defaultName = nullptr,
+        NativeWindowHandle owner = nullptr
+    ) {
+        // Build Zenity command
+        std::string cmd = "zenity --file-selection --save --confirm-overwrite --title=\"";
+        cmd += title ? title : "Save File";
+        cmd += "\"";
+
+        if (ext && *ext) {
+            std::string pattern = ext;
+            if (pattern.rfind("*.") != 0) {
+                if (pattern[0] == '.') {
+                    pattern = "*" + pattern;
+                } else {
+                    pattern = "*." + pattern;
+                }   
+            }
+            cmd += " --file-filter=\"*";
+            cmd += pattern.substr(1);
+            cmd += "\"";
+        }
+
+        if (defaultName && *defaultName) {
+            cmd += " --filename=\"";
+            cmd += defaultName;
+            cmd += "\"";
+        }
+
+        cmd += " 2>/dev/null"; // suppress warnings
+
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) {
+            return {};
+        }
+
+        char buffer[4096];
+        std::string result;
+        while (fgets(buffer, sizeof(buffer), pipe)) {
+            result += buffer;
+        } 
+        pclose(pipe);
+
+        if (!result.empty() && result.back() == '\n') {
+            result.pop_back();
+        }
+
+        return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
+    }
+}

--- a/LauraEditor/src/Platform/Linux/Dialogs/FolderPickerDialog.h
+++ b/LauraEditor/src/Platform/Linux/Dialogs/FolderPickerDialog.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace Laura
+{
+
+    using NativeWindowHandle = void*; // Ignored on Linux
+
+    inline std::filesystem::path FolderPickerDialog(const std::string& title = "Select Folder", NativeWindowHandle owner = nullptr) {
+        std::string cmd = "zenity --file-selection --directory --title=\"" + title + "\" 2>/dev/null";
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) {
+            return {};
+        }
+
+        char buffer[4096];
+        std::string result;
+        while (fgets(buffer, sizeof(buffer), pipe)) {
+            result += buffer;
+        }
+        pclose(pipe);
+
+        if (!result.empty() && result.back() == '\n') {
+            result.pop_back();
+        }
+
+        return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
+    }
+}

--- a/LauraEditor/src/Platform/Windows/Dialogs/FilePickerDialog.h
+++ b/LauraEditor/src/Platform/Windows/Dialogs/FilePickerDialog.h
@@ -3,198 +3,119 @@
 #include <filesystem>
 #include <string>
 #include <vector>
-#include <cstdlib>
-#include <cstdio>
-
-#if defined(_WIN32)
 #include <windows.h>
-#include <commdlg.h> // OPENFILENAME{A,W}
+#include <commdlg.h> // OPENFILENAMEA
 #include <format>
-#endif
 
-namespace Laura
-{
+namespace Laura {
 
-#if defined(_WIN32)
-using NativeWindowHandle = HWND;
-#else
-using NativeWindowHandle = void*; // Ignored on Linux
-#endif
+    using NativeWindowHandle = HWND;
 
-inline std::filesystem::path FilePickerDialog(
-    const char* ext,
-    const char* title,
-    NativeWindowHandle owner = nullptr
-) {
-#if defined(_WIN32)
+    inline std::filesystem::path FilePickerDialog(
+        const char* ext,
+        const char* title,
+        NativeWindowHandle owner = nullptr)
+    {
+        char buff[MAX_PATH] = {};
 
-    char buff[MAX_PATH] = {};
+        std::string filter = std::format("{} Files", ext);
+		filter.push_back('\0');
+		filter += std::format(" * {}", ext);
+		filter.push_back('\0');
+		filter.push_back('\0');
 
-    std::string filter = std::format("{} Files", ext);
-    filter.push_back('\0');
-    filter += std::format("*.{}", ext);
-    filter.push_back('\0');
-    filter.push_back('\0');
+        OPENFILENAMEA ofn = {};
+        ofn.lStructSize = sizeof(ofn);
+        ofn.hwndOwner   = owner;
+        ofn.lpstrFilter = filter.c_str();
+        ofn.lpstrTitle  = title;
+        ofn.nMaxFile    = static_cast<DWORD>(sizeof(buff));
+        ofn.lpstrFile   = buff;
+        ofn.Flags       = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
 
-    OPENFILENAMEA ofn = {};
-    ofn.lStructSize = sizeof(ofn);
-    ofn.hwndOwner   = reinterpret_cast<HWND>(owner); // cast to HWND
-    ofn.lpstrFilter = filter.c_str();
-    ofn.lpstrTitle  = title;
-    ofn.nMaxFile    = static_cast<DWORD>(sizeof(buff));
-    ofn.lpstrFile   = buff;
-    ofn.Flags       = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
-
-    if (GetOpenFileNameA(&ofn))
-        return std::filesystem::path(buff);
-
-    return {};
-
-#elif defined(__linux__)
-
-    // Build Zenity command
-    std::string cmd = "zenity --file-selection --title=\"";
-    cmd += title ? title : "Select File";
-    cmd += "\"";
-
-    if (ext && *ext) {
-        std::string pattern = ext;
-        if (pattern.rfind("*.") != 0) {
-            if (pattern[0] == '.') pattern = "*" + pattern;
-            else pattern = "*." + pattern;
+        if (GetOpenFileNameA(&ofn)) {
+            return std::filesystem::path(buff);
         }
-        cmd += " --file-filter=\"*";
-        cmd += pattern.substr(1);
-        cmd += "\"";
+        return {}; // empty path if cancelled
     }
 
-    cmd += " 2>/dev/null"; // suppress warnings
+    inline std::filesystem::path SaveFileDialog(
+        const char* ext,
+        const char* title,
+        const char* defaultName = nullptr,
+        NativeWindowHandle owner = nullptr)
+    {
+        // Use Unicode version for proper Unicode support and longer paths
+        const int MAX_UNICODE_PATH = 32768; // Much longer than MAX_PATH
+        std::vector<wchar_t> buff(MAX_UNICODE_PATH, L'\0');
 
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return {};
+        // Build filter string in Unicode
+        std::string filterStr;
+        if (ext && strlen(ext) > 0) {
+            // Format: "Description\0*.ext\0\0"
+            std::string extension = ext;
 
-    char buffer[4096];
-    std::string result;
-    while (fgets(buffer, sizeof(buffer), pipe)) result += buffer;
-    pclose(pipe);
+            // Ensure extension starts with "*."
+            if (extension.find("*.") != 0) {
+                if (extension[0] == '.') {
+                    extension = "*" + extension;  // ".lrproj" -> "*.lrproj"
+                } else {
+                    extension = "*." + extension; // "lrproj" -> "*.lrproj"
+                }
+            }
 
-    if (!result.empty() && result.back() == '\n') result.pop_back();
-    return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
-
-#else
-#error "FilePickerDialog not implemented for this platform"
-#endif
-}
-
-inline std::filesystem::path SaveFileDialog(
-    const char* ext,
-    const char* title,
-    const char* defaultName = nullptr,
-    NativeWindowHandle owner = nullptr
-) {
-#if defined(_WIN32)
-
-    const int MAX_UNICODE_PATH = 32768;
-    std::vector<wchar_t> buff(MAX_UNICODE_PATH, L'\0');
-
-    // Build filter string in Unicode
-    std::string filterStr;
-    if (ext && *ext) {
-        std::string extension = ext;
-        if (extension.find("*.") != 0) {
-            if (extension[0] == '.') extension = "*" + extension;
-            else extension = "*." + extension;
+            filterStr = std::format("{} Files", ext);  // Use original ext for description
+            filterStr.push_back('\0');     // Null terminate description
+            filterStr += extension;        // Add the extension pattern (e.g., "*.lrproj")
+            filterStr.push_back('\0');     // Null terminate pattern
+        } else {
+            // No filter - show all files
+            filterStr = "All Files";
+            filterStr.push_back('\0');     // Null terminate description
+            filterStr += "*.*";            // Add the all files pattern
+            filterStr.push_back('\0');     // Null terminate pattern
         }
-        filterStr = std::format("{} Files", ext);
-        filterStr.push_back('\0');
-        filterStr += extension;
-        filterStr.push_back('\0');
-    } else {
-        filterStr = "All Files";
-        filterStr.push_back('\0');
-        filterStr += "*.*";
-        filterStr.push_back('\0');
-    }
-    filterStr.push_back('\0'); // double null
+        filterStr.push_back('\0');        // Double null terminator
 
-    int filterSize = MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, nullptr, 0);
-    std::vector<wchar_t> wfilter(filterSize > 0 ? filterSize : 1, L'\0');
-    if (filterSize > 0) {
-        MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, wfilter.data(), filterSize);
-    }
-
-    std::vector<wchar_t> wtitle;
-    if (title && *title) {
-        int titleSize = MultiByteToWideChar(CP_UTF8, 0, title, -1, nullptr, 0);
-        if (titleSize > 0) {
-            wtitle.resize(titleSize, L'\0');
-            MultiByteToWideChar(CP_UTF8, 0, title, -1, wtitle.data(), titleSize);
+        // Convert filter to wide string
+        int filterSize = MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, nullptr, 0);
+        std::vector<wchar_t> wfilter(filterSize > 0 ? filterSize : 1, L'\0');
+        if (filterSize > 0) {
+            MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, wfilter.data(), filterSize);
         }
-    }
 
-    if (defaultName && *defaultName) {
-        int nameSize = MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, nullptr, 0);
-        if (nameSize > 0 && nameSize < buff.size()) {
-            std::vector<wchar_t> wdefaultName(nameSize, L'\0');
-            MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, wdefaultName.data(), nameSize);
-            std::copy(wdefaultName.begin(), wdefaultName.end(), buff.begin());
+        // Convert title to wide string
+        std::vector<wchar_t> wtitle;
+        if (title && strlen(title) > 0) {
+            int titleSize = MultiByteToWideChar(CP_UTF8, 0, title, -1, nullptr, 0);
+            if (titleSize > 0) {
+                wtitle.resize(titleSize, L'\0');
+                MultiByteToWideChar(CP_UTF8, 0, title, -1, wtitle.data(), titleSize);
+            }
         }
-    }
 
-    OPENFILENAMEW ofn = {};
-    ofn.lStructSize = sizeof(ofn);
-    ofn.hwndOwner   = reinterpret_cast<HWND>(owner); // cast to HWND
-    ofn.lpstrFilter = wfilter.data();
-    ofn.lpstrTitle  = wtitle.empty() ? nullptr : wtitle.data();
-    ofn.nMaxFile    = static_cast<DWORD>(buff.size());
-    ofn.lpstrFile   = buff.data();
-    ofn.Flags       = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
-
-    if (GetSaveFileNameW(&ofn)) {
-        return std::filesystem::path(buff.data());
-    }
-    return {};
-
-#elif defined(__linux__)
-
-    // Build Zenity command
-    std::string cmd = "zenity --file-selection --save --confirm-overwrite --title=\"";
-    cmd += title ? title : "Save File";
-    cmd += "\"";
-
-    if (ext && *ext) {
-        std::string pattern = ext;
-        if (pattern.rfind("*.") != 0) {
-            if (pattern[0] == '.') pattern = "*" + pattern;
-            else pattern = "*." + pattern;
+        // Convert default name to wide string and copy to buffer
+        if (defaultName && strlen(defaultName) > 0) {
+            int nameSize = MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, nullptr, 0);
+            if (nameSize > 0 && nameSize < buff.size()) {
+                std::vector<wchar_t> wdefaultName(nameSize, L'\0');
+                MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, wdefaultName.data(), nameSize);
+                std::copy(wdefaultName.begin(), wdefaultName.end(), buff.begin());
+            }
         }
-        cmd += " --file-filter=\"*";
-        cmd += pattern.substr(1);
-        cmd += "\"";
+
+        OPENFILENAMEW ofn = {};
+        ofn.lStructSize = sizeof(ofn);
+        ofn.hwndOwner   = owner;
+        ofn.lpstrFilter = wfilter.data();
+        ofn.lpstrTitle  = wtitle.empty() ? nullptr : wtitle.data();
+        ofn.nMaxFile    = static_cast<DWORD>(buff.size());
+        ofn.lpstrFile   = buff.data();
+        ofn.Flags       = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
+
+        if (GetSaveFileNameW(&ofn)) {
+            return std::filesystem::path(buff.data());
+        }
+        return {}; // empty path if cancelled
     }
-
-    if (defaultName && *defaultName) {
-        cmd += " --filename=\"";
-        cmd += defaultName;
-        cmd += "\"";
-    }
-
-    cmd += " 2>/dev/null"; // suppress warnings
-
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return {};
-
-    char buffer[4096];
-    std::string result;
-    while (fgets(buffer, sizeof(buffer), pipe)) result += buffer;
-    pclose(pipe);
-
-    if (!result.empty() && result.back() == '\n') result.pop_back();
-    return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
-
-#else
-#error "SaveFileDialog not implemented for this platform"
-#endif
-}
-
 }

--- a/LauraEditor/src/Platform/Windows/Dialogs/FilePickerDialog.h
+++ b/LauraEditor/src/Platform/Windows/Dialogs/FilePickerDialog.h
@@ -2,20 +2,13 @@
 
 #include <filesystem>
 #include <string>
-#include <vector>
-#include <windows.h>
 #include <commdlg.h> // OPENFILENAMEA
 #include <format>
 
-namespace Laura {
+namespace Laura
+{
 
-    using NativeWindowHandle = HWND;
-
-    inline std::filesystem::path FilePickerDialog(
-        const char* ext,
-        const char* title,
-        NativeWindowHandle owner = nullptr)
-    {
+    inline std::filesystem::path FilePickerDialog(const char* ext, const char* title, HWND owner = nullptr) {
         char buff[MAX_PATH] = {};
 
         std::string filter = std::format("{} Files", ext);
@@ -39,12 +32,7 @@ namespace Laura {
         return {}; // empty path if cancelled
     }
 
-    inline std::filesystem::path SaveFileDialog(
-        const char* ext,
-        const char* title,
-        const char* defaultName = nullptr,
-        NativeWindowHandle owner = nullptr)
-    {
+    inline std::filesystem::path SaveFileDialog(const char* ext, const char* title, const char* defaultName = nullptr, HWND owner = nullptr) {
         // Use Unicode version for proper Unicode support and longer paths
         const int MAX_UNICODE_PATH = 32768; // Much longer than MAX_PATH
         std::vector<wchar_t> buff(MAX_UNICODE_PATH, L'\0');

--- a/LauraEditor/src/Platform/Windows/Dialogs/FilePickerDialog.h
+++ b/LauraEditor/src/Platform/Windows/Dialogs/FilePickerDialog.h
@@ -2,108 +2,199 @@
 
 #include <filesystem>
 #include <string>
-#include <commdlg.h> // OPENFILENAMEA
+#include <vector>
+#include <cstdlib>
+#include <cstdio>
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <commdlg.h> // OPENFILENAME{A,W}
 #include <format>
+#endif
 
 namespace Laura
 {
 
-    inline std::filesystem::path FilePickerDialog(const char* ext, const char* title, HWND owner = nullptr) {
-        char buff[MAX_PATH] = {};
+#if defined(_WIN32)
+using NativeWindowHandle = HWND;
+#else
+using NativeWindowHandle = void*; // Ignored on Linux
+#endif
 
-        std::string filter = std::format("{} Files", ext);
-		filter.push_back('\0');
-		filter += std::format(" * {}", ext);
-		filter.push_back('\0');
-		filter.push_back('\0');
+inline std::filesystem::path FilePickerDialog(
+    const char* ext,
+    const char* title,
+    NativeWindowHandle owner = nullptr
+) {
+#if defined(_WIN32)
 
-        OPENFILENAMEA ofn = {};
-        ofn.lStructSize = sizeof(ofn);
-        ofn.hwndOwner   = owner;
-        ofn.lpstrFilter = filter.c_str();
-        ofn.lpstrTitle  = title;
-        ofn.nMaxFile    = static_cast<DWORD>(sizeof(buff));
-        ofn.lpstrFile   = buff;
-        ofn.Flags       = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
+    char buff[MAX_PATH] = {};
 
-        if (GetOpenFileNameA(&ofn)) {
-            return std::filesystem::path(buff);
+    std::string filter = std::format("{} Files", ext);
+    filter.push_back('\0');
+    filter += std::format("*.{}", ext);
+    filter.push_back('\0');
+    filter.push_back('\0');
+
+    OPENFILENAMEA ofn = {};
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner   = reinterpret_cast<HWND>(owner); // cast to HWND
+    ofn.lpstrFilter = filter.c_str();
+    ofn.lpstrTitle  = title;
+    ofn.nMaxFile    = static_cast<DWORD>(sizeof(buff));
+    ofn.lpstrFile   = buff;
+    ofn.Flags       = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_NOCHANGEDIR;
+
+    if (GetOpenFileNameA(&ofn))
+        return std::filesystem::path(buff);
+
+    return {};
+
+#elif defined(__linux__)
+
+    // Build Zenity command
+    std::string cmd = "zenity --file-selection --title=\"";
+    cmd += title ? title : "Select File";
+    cmd += "\"";
+
+    if (ext && *ext) {
+        std::string pattern = ext;
+        if (pattern.rfind("*.") != 0) {
+            if (pattern[0] == '.') pattern = "*" + pattern;
+            else pattern = "*." + pattern;
         }
-        return {}; // empty path if cancelled
+        cmd += " --file-filter=\"*";
+        cmd += pattern.substr(1);
+        cmd += "\"";
     }
 
-    inline std::filesystem::path SaveFileDialog(const char* ext, const char* title, const char* defaultName = nullptr, HWND owner = nullptr) {
-        // Use Unicode version for proper Unicode support and longer paths
-        const int MAX_UNICODE_PATH = 32768; // Much longer than MAX_PATH
-        std::vector<wchar_t> buff(MAX_UNICODE_PATH, L'\0');
+    cmd += " 2>/dev/null"; // suppress warnings
 
-        // Build filter string in Unicode
-        std::string filterStr;
-        if (ext && strlen(ext) > 0) {
-            // Format: "Description\0*.ext\0\0"
-            std::string extension = ext;
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) return {};
 
-            // Ensure extension starts with "*."
-            if (extension.find("*.") != 0) {
-                if (extension[0] == '.') {
-                    extension = "*" + extension;  // ".lrproj" -> "*.lrproj"
-                } else {
-                    extension = "*." + extension; // "lrproj" -> "*.lrproj"
-                }
-            }
+    char buffer[4096];
+    std::string result;
+    while (fgets(buffer, sizeof(buffer), pipe)) result += buffer;
+    pclose(pipe);
 
-            filterStr = std::format("{} Files", ext);  // Use original ext for description
-            filterStr.push_back('\0');     // Null terminate description
-            filterStr += extension;        // Add the extension pattern (e.g., "*.lrproj")
-            filterStr.push_back('\0');     // Null terminate pattern
-        } else {
-            // No filter - show all files
-            filterStr = "All Files";
-            filterStr.push_back('\0');     // Null terminate description
-            filterStr += "*.*";            // Add the all files pattern
-            filterStr.push_back('\0');     // Null terminate pattern
+    if (!result.empty() && result.back() == '\n') result.pop_back();
+    return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
+
+#else
+#error "FilePickerDialog not implemented for this platform"
+#endif
+}
+
+inline std::filesystem::path SaveFileDialog(
+    const char* ext,
+    const char* title,
+    const char* defaultName = nullptr,
+    NativeWindowHandle owner = nullptr
+) {
+#if defined(_WIN32)
+
+    const int MAX_UNICODE_PATH = 32768;
+    std::vector<wchar_t> buff(MAX_UNICODE_PATH, L'\0');
+
+    // Build filter string in Unicode
+    std::string filterStr;
+    if (ext && *ext) {
+        std::string extension = ext;
+        if (extension.find("*.") != 0) {
+            if (extension[0] == '.') extension = "*" + extension;
+            else extension = "*." + extension;
         }
-        filterStr.push_back('\0');        // Double null terminator
-
-        // Convert filter to wide string
-        int filterSize = MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, nullptr, 0);
-        std::vector<wchar_t> wfilter(filterSize > 0 ? filterSize : 1, L'\0');
-        if (filterSize > 0) {
-            MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, wfilter.data(), filterSize);
-        }
-
-        // Convert title to wide string
-        std::vector<wchar_t> wtitle;
-        if (title && strlen(title) > 0) {
-            int titleSize = MultiByteToWideChar(CP_UTF8, 0, title, -1, nullptr, 0);
-            if (titleSize > 0) {
-                wtitle.resize(titleSize, L'\0');
-                MultiByteToWideChar(CP_UTF8, 0, title, -1, wtitle.data(), titleSize);
-            }
-        }
-
-        // Convert default name to wide string and copy to buffer
-        if (defaultName && strlen(defaultName) > 0) {
-            int nameSize = MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, nullptr, 0);
-            if (nameSize > 0 && nameSize < buff.size()) {
-                std::vector<wchar_t> wdefaultName(nameSize, L'\0');
-                MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, wdefaultName.data(), nameSize);
-                std::copy(wdefaultName.begin(), wdefaultName.end(), buff.begin());
-            }
-        }
-
-        OPENFILENAMEW ofn = {};
-        ofn.lStructSize = sizeof(ofn);
-        ofn.hwndOwner   = owner;
-        ofn.lpstrFilter = wfilter.data();
-        ofn.lpstrTitle  = wtitle.empty() ? nullptr : wtitle.data();
-        ofn.nMaxFile    = static_cast<DWORD>(buff.size());
-        ofn.lpstrFile   = buff.data();
-        ofn.Flags       = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
-
-        if (GetSaveFileNameW(&ofn)) {
-            return std::filesystem::path(buff.data());
-        }
-        return {}; // empty path if cancelled
+        filterStr = std::format("{} Files", ext);
+        filterStr.push_back('\0');
+        filterStr += extension;
+        filterStr.push_back('\0');
+    } else {
+        filterStr = "All Files";
+        filterStr.push_back('\0');
+        filterStr += "*.*";
+        filterStr.push_back('\0');
     }
+    filterStr.push_back('\0'); // double null
+
+    int filterSize = MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, nullptr, 0);
+    std::vector<wchar_t> wfilter(filterSize > 0 ? filterSize : 1, L'\0');
+    if (filterSize > 0) {
+        MultiByteToWideChar(CP_UTF8, 0, filterStr.c_str(), -1, wfilter.data(), filterSize);
+    }
+
+    std::vector<wchar_t> wtitle;
+    if (title && *title) {
+        int titleSize = MultiByteToWideChar(CP_UTF8, 0, title, -1, nullptr, 0);
+        if (titleSize > 0) {
+            wtitle.resize(titleSize, L'\0');
+            MultiByteToWideChar(CP_UTF8, 0, title, -1, wtitle.data(), titleSize);
+        }
+    }
+
+    if (defaultName && *defaultName) {
+        int nameSize = MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, nullptr, 0);
+        if (nameSize > 0 && nameSize < buff.size()) {
+            std::vector<wchar_t> wdefaultName(nameSize, L'\0');
+            MultiByteToWideChar(CP_UTF8, 0, defaultName, -1, wdefaultName.data(), nameSize);
+            std::copy(wdefaultName.begin(), wdefaultName.end(), buff.begin());
+        }
+    }
+
+    OPENFILENAMEW ofn = {};
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner   = reinterpret_cast<HWND>(owner); // cast to HWND
+    ofn.lpstrFilter = wfilter.data();
+    ofn.lpstrTitle  = wtitle.empty() ? nullptr : wtitle.data();
+    ofn.nMaxFile    = static_cast<DWORD>(buff.size());
+    ofn.lpstrFile   = buff.data();
+    ofn.Flags       = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
+
+    if (GetSaveFileNameW(&ofn)) {
+        return std::filesystem::path(buff.data());
+    }
+    return {};
+
+#elif defined(__linux__)
+
+    // Build Zenity command
+    std::string cmd = "zenity --file-selection --save --confirm-overwrite --title=\"";
+    cmd += title ? title : "Save File";
+    cmd += "\"";
+
+    if (ext && *ext) {
+        std::string pattern = ext;
+        if (pattern.rfind("*.") != 0) {
+            if (pattern[0] == '.') pattern = "*" + pattern;
+            else pattern = "*." + pattern;
+        }
+        cmd += " --file-filter=\"*";
+        cmd += pattern.substr(1);
+        cmd += "\"";
+    }
+
+    if (defaultName && *defaultName) {
+        cmd += " --filename=\"";
+        cmd += defaultName;
+        cmd += "\"";
+    }
+
+    cmd += " 2>/dev/null"; // suppress warnings
+
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) return {};
+
+    char buffer[4096];
+    std::string result;
+    while (fgets(buffer, sizeof(buffer), pipe)) result += buffer;
+    pclose(pipe);
+
+    if (!result.empty() && result.back() == '\n') result.pop_back();
+    return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
+
+#else
+#error "SaveFileDialog not implemented for this platform"
+#endif
+}
+
 }

--- a/LauraEditor/src/Platform/Windows/Dialogs/FolderPickerDialog.h
+++ b/LauraEditor/src/Platform/Windows/Dialogs/FolderPickerDialog.h
@@ -2,89 +2,51 @@
 
 #include <filesystem>
 #include <string>
+#include <windows.h>
+#include <shobjidl.h> // IFileDialog
 
 namespace Laura
 {
 
-#if defined(_WIN32)
-#include <windows.h>
-#include <shobjidl.h> // IFileDialog
-using NativeWindowHandle = HWND;
-#else
-using NativeWindowHandle = void*; // Ignored on Linux
-#endif
+    using NativeWindowHandle = HWND;
 
-inline std::filesystem::path FolderPickerDialog(
-    const std::string& title = "Select Folder",
-    NativeWindowHandle owner = nullptr
-) {
-#if defined(_WIN32)
-    IFileDialog* pDialog = nullptr;
-    HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL,
-                                  IID_IFileDialog, reinterpret_cast<void**>(&pDialog));
-    if (FAILED(hr) || !pDialog) {
-        return {};
-    }
+    inline std::filesystem::path FolderPickerDialog(const std::string& title = "Select Folder", NativeWindowHandle owner = nullptr) {
+		IFileDialog* pDialog = nullptr;
+		HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL,
+									  IID_IFileDialog, reinterpret_cast<void**>(&pDialog));
+		if (FAILED(hr) || !pDialog) {
+			return {};
+		}
+		// Tell the dialog to pick folders
+		DWORD options;
+		pDialog->GetOptions(&options);
+		pDialog->SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+        std::wstring wtitle(title.begin(), title.end());
+        pDialog->SetTitle(wtitle.c_str());
 
-    // Tell the dialog to pick folders
-    DWORD options;
-    pDialog->GetOptions(&options);
-    pDialog->SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+		// Show the dialog
+		hr = pDialog->Show(owner);
+		if (FAILED(hr)) {
+			pDialog->Release();
+            return {};
+		}
+		// Get the result
+		IShellItem* pItem = nullptr;
+		hr = pDialog->GetResult(&pItem);
+		if (FAILED(hr) || !pItem) {
+			pDialog->Release();
+            return {};
+		}
+		PWSTR pszPath = nullptr;
+		hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
+        std::filesystem::path result{};
 
-    // Set title
-    std::wstring wtitle(title.begin(), title.end());
-    pDialog->SetTitle(wtitle.c_str());
-
-    // Show the dialog, passing owner
-    hr = pDialog->Show(reinterpret_cast<HWND>(owner)); // cast to HWND
-    if (FAILED(hr)) {
-        pDialog->Release();
-        return {};
-    }
-
-    // Get the result
-    IShellItem* pItem = nullptr;
-    hr = pDialog->GetResult(&pItem);
-    if (FAILED(hr) || !pItem) {
-        pDialog->Release();
-        return {};
-    }
-
-    PWSTR pszPath = nullptr;
-    std::filesystem::path result{};
-    if (SUCCEEDED(hr)) {
-        hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
-        if (SUCCEEDED(hr) && pszPath) {
-            result = std::filesystem::path(pszPath);
-            CoTaskMemFree(pszPath);
-        }
-    }
-
-    pItem->Release();
-    pDialog->Release();
-    return result;
-
-#elif defined(__linux__)
-    std::string cmd = "zenity --file-selection --directory --title=\"" + title + "\" 2>/dev/null";
-    FILE* pipe = popen(cmd.c_str(), "r");
-    if (!pipe) return {};
-
-    char buffer[4096];
-    std::string result;
-    while (fgets(buffer, sizeof(buffer), pipe)) {
-        result += buffer;
-    }
-    pclose(pipe);
-
-    if (!result.empty() && result.back() == '\n') {
-        result.pop_back();
-    }
-
-    return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
-
-#else
-    #error "FolderPickerDialog not implemented on this platform"
-#endif
-}
-
+		if (SUCCEEDED(hr)) {
+			result = std::filesystem::path(pszPath);
+			CoTaskMemFree(pszPath);
+		}
+		pItem->Release();
+		pDialog->Release();
+		return result;
+	}
 }

--- a/LauraEditor/src/Platform/Windows/Dialogs/FolderPickerDialog.h
+++ b/LauraEditor/src/Platform/Windows/Dialogs/FolderPickerDialog.h
@@ -8,9 +8,7 @@
 namespace Laura
 {
 
-    using NativeWindowHandle = HWND;
-
-    inline std::filesystem::path FolderPickerDialog(const std::string& title = "Select Folder", NativeWindowHandle owner = nullptr) {
+    inline std::filesystem::path FolderPickerDialog(const std::string& title = "Select Folder", HWND owner = nullptr) {
 		IFileDialog* pDialog = nullptr;
 		HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL,
 									  IID_IFileDialog, reinterpret_cast<void**>(&pDialog));

--- a/LauraEditor/src/Platform/Windows/Dialogs/FolderPickerDialog.h
+++ b/LauraEditor/src/Platform/Windows/Dialogs/FolderPickerDialog.h
@@ -2,49 +2,89 @@
 
 #include <filesystem>
 #include <string>
-#include <windows.h>
-#include <shobjidl.h> // IFileDialog
 
 namespace Laura
 {
 
-    inline std::filesystem::path FolderPickerDialog(const std::string& title = "Select Folder", HWND owner = nullptr) {
-		IFileDialog* pDialog = nullptr;
-		HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL,
-									  IID_IFileDialog, reinterpret_cast<void**>(&pDialog));
-		if (FAILED(hr) || !pDialog) {
-			return {};
-		}
-		// Tell the dialog to pick folders
-		DWORD options;
-		pDialog->GetOptions(&options);
-		pDialog->SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
-        std::wstring wtitle(title.begin(), title.end());
-        pDialog->SetTitle(wtitle.c_str());
+#if defined(_WIN32)
+#include <windows.h>
+#include <shobjidl.h> // IFileDialog
+using NativeWindowHandle = HWND;
+#else
+using NativeWindowHandle = void*; // Ignored on Linux
+#endif
 
-		// Show the dialog
-		hr = pDialog->Show(owner);
-		if (FAILED(hr)) {
-			pDialog->Release();
-            return {};
-		}
-		// Get the result
-		IShellItem* pItem = nullptr;
-		hr = pDialog->GetResult(&pItem);
-		if (FAILED(hr) || !pItem) {
-			pDialog->Release();
-            return {};
-		}
-		PWSTR pszPath = nullptr;
-		hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
-        std::filesystem::path result{};
+inline std::filesystem::path FolderPickerDialog(
+    const std::string& title = "Select Folder",
+    NativeWindowHandle owner = nullptr
+) {
+#if defined(_WIN32)
+    IFileDialog* pDialog = nullptr;
+    HRESULT hr = CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_ALL,
+                                  IID_IFileDialog, reinterpret_cast<void**>(&pDialog));
+    if (FAILED(hr) || !pDialog) {
+        return {};
+    }
 
-		if (SUCCEEDED(hr)) {
-			result = std::filesystem::path(pszPath);
-			CoTaskMemFree(pszPath);
-		}
-		pItem->Release();
-		pDialog->Release();
-		return result;
-	}
+    // Tell the dialog to pick folders
+    DWORD options;
+    pDialog->GetOptions(&options);
+    pDialog->SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM);
+
+    // Set title
+    std::wstring wtitle(title.begin(), title.end());
+    pDialog->SetTitle(wtitle.c_str());
+
+    // Show the dialog, passing owner
+    hr = pDialog->Show(reinterpret_cast<HWND>(owner)); // cast to HWND
+    if (FAILED(hr)) {
+        pDialog->Release();
+        return {};
+    }
+
+    // Get the result
+    IShellItem* pItem = nullptr;
+    hr = pDialog->GetResult(&pItem);
+    if (FAILED(hr) || !pItem) {
+        pDialog->Release();
+        return {};
+    }
+
+    PWSTR pszPath = nullptr;
+    std::filesystem::path result{};
+    if (SUCCEEDED(hr)) {
+        hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
+        if (SUCCEEDED(hr) && pszPath) {
+            result = std::filesystem::path(pszPath);
+            CoTaskMemFree(pszPath);
+        }
+    }
+
+    pItem->Release();
+    pDialog->Release();
+    return result;
+
+#elif defined(__linux__)
+    std::string cmd = "zenity --file-selection --directory --title=\"" + title + "\" 2>/dev/null";
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe) return {};
+
+    char buffer[4096];
+    std::string result;
+    while (fgets(buffer, sizeof(buffer), pipe)) {
+        result += buffer;
+    }
+    pclose(pipe);
+
+    if (!result.empty() && result.back() == '\n') {
+        result.pop_back();
+    }
+
+    return result.empty() ? std::filesystem::path{} : std::filesystem::path(result);
+
+#else
+    #error "FolderPickerDialog not implemented on this platform"
+#endif
+}
+
 }

--- a/README.md
+++ b/README.md
@@ -56,12 +56,20 @@ The project is structured into three CMake targets:
 - **Structured logging** via spdlog
 
 ## Supported Platforms
-Laura currently targets **Windows (x64)** and builds with the MSVC toolchain.
 
-> [!IMPORTANT]
-> Note: The root `CMakeLists.txt` enforces Windows-only for now and enables multi-threaded compilation under MSVC.
+### Experimental Linux support
+To enable file dialogs, make sure **Zenity** is installed.
 
-Experimental Linux support:
+```bash
+# Install Zenity
+sudo apt install zenity        # Ubuntu / Debian
+sudo pacman -S zenity          # Arch
+
+# Test installation
+zenity --info --text="Hello World!"
+```
+
+**Build & Run**
 ```bash
 # Compile with g++ (GCC)
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_INSTALL=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
@@ -71,7 +79,7 @@ cmake --build build --target install -j$(nproc)
 ./build/install/LauraEditor
 ```
 
-## Getting Started
+## Getting Started Windows
 
 
 ### Prerequisites
@@ -131,7 +139,8 @@ git submodule update --init --recursive
 > [!TIP]
 > To hide the console window for applications, set `ENABLE_CONSOLE=OFF` in the root CMakeLists.txt or pass `-DENABLE_CONSOLE=OFF` when configuring.
 
-
+> [!TIP]
+> The root `CMakeLists.txt` enables multi-threaded compilation under MSVC.
 
 ## Project Structure
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Laura currently targets **Windows (x64)** and builds with the MSVC toolchain.
 > [!IMPORTANT]
 > Note: The root `CMakeLists.txt` enforces Windows-only for now and enables multi-threaded compilation under MSVC.
 
+Experimental Linux support:
+```bash
+# Compile with g++ (GCC)
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_INSTALL=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+cmake --build build --target install -j$(nproc)
+
+# Run
+./build/install/LauraEditor
+```
+
 ## Getting Started
 
 


### PR DESCRIPTION
What's new

- Updated several `#include` statements to match **case-sensitive file paths** for Linux compilation.
- Preserved the `HWND owner` parameter in dialog functions:
  - **Windows:** passed through as before.
  - **Linux:** ignored (no equivalent).
- Successfully built and tested on Linux (Arch) using **g++ (GCC)**.
- Added Linux build instructions to the README.
- Verified that the editor runs correctly on Linux.
- Project export works on Linux.