### PR TITLE
Remove unnecessary SceneManager.h include

### DIFF
--- a/Laura/src/Project/Scene/SceneManager.cpp
+++ b/Laura/src/Project/Scene/SceneManager.cpp
@@ -1,5 +1,4 @@
 #include "SceneManager.h"
-#include "Project/Scene/SceneManager.h"
 
 namespace Laura
 {


### PR DESCRIPTION
- Removed the redundant `#include "Project/Scene/SceneManager.h"` from `SceneManager.cpp`.